### PR TITLE
fix: 扩展默认主题时的报错问题

### DIFF
--- a/docs/.vuepress/theme/index.js
+++ b/docs/.vuepress/theme/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extend: '@vuepress/theme-default'
+}


### PR DESCRIPTION
扩展默认主题需要做相应配置，参见：https://vuepress.vuejs.org/zh/theme/inheritance.html#%E4%BD%BF%E7%94%A8